### PR TITLE
Fix faltant genres at movies search ( were shown no more than three if the movie had more than three genres )

### DIFF
--- a/src/app/core/services/genre.service.ts
+++ b/src/app/core/services/genre.service.ts
@@ -36,7 +36,7 @@ export class GenreService {
   }
 
   getMultiple(ids: number[], maxElements?: number): Observable<Genre[]>{
-    maxElements? null : maxElements = ids.length - 1 ; 
+    maxElements? null : maxElements = ids.length  ; 
     return forkJoin(ids.slice(0, maxElements).map(
       (id: number) => {
         return this.get(id).pipe(

--- a/src/app/genre/shared/genres-list/genres-list.component.ts
+++ b/src/app/genre/shared/genres-list/genres-list.component.ts
@@ -12,9 +12,8 @@ export class GenresListComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {
-    this.maxItems = 0;
-    if ( this.genres ) {
-      this.maxItems = this.genres.length - 1; 
+    if ( this.genres && !this.maxItems ) {
+      this.maxItems = this.genres.length; 
       this.genres.slice(0,this.maxItems);
     }
   }

--- a/src/app/movie/movies-list-table/movies-list-table.component.ts
+++ b/src/app/movie/movies-list-table/movies-list-table.component.ts
@@ -45,7 +45,7 @@ export class MoviesListTableComponent implements OnInit, OnChanges {
     this.movies = this.movies.pipe(map(
       (movies: Movie[])=>{
         return movies.map(movie => {
-          movie.genres = this.genreService.getMultiple(movie.genre_ids, 3).pipe(debounceTime(100));
+          movie.genres = this.genreService.getMultiple(movie.genre_ids).pipe(debounceTime(100));
           return movie;
           }); }));
   }


### PR DESCRIPTION
The movie`s genres were limited to maximum 3 because for each genre in a movie one petition has been maded to the api, with cache support for that ( see genres service ) this limitation does not exist more, now this limit has been removed